### PR TITLE
Create maven.yml

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,35 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+    - name: Update dependency graph
+      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6


### PR DESCRIPTION
## Sourcery 摘要

添加一个 GitHub Actions 工作流，用于使用 Maven 构建 Java 项目、缓存依赖项，并在推送到 main 分支和向 main 分支发起拉取请求时更新依赖关系图。

CI:
- 在 Ubuntu 上使用 Maven 设置 Java CI，使用 JDK 21、依赖项缓存和包构建步骤
- 添加依赖关系图提交步骤以增强 Dependabot 警报

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a GitHub Actions workflow to build the Java project with Maven, cache dependencies, and update the dependency graph on push and pull requests to main

CI:
- Set up Java CI with Maven on Ubuntu, using JDK 21, dependency caching, and package build steps
- Add dependency graph submission step to enhance Dependabot alerts

</details>