### PR TITLE
feat: 升级jdk25

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up JDK 25
       uses: actions/setup-java@v5
       with:
-        java-version: '21'
+        java-version: '25'
         distribution: 'temurin'
 
     # 获取 mvnd 最新 release 版本号

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
                 <version>3.14.1</version>
                 <configuration>
                     <!-- Java 版本 -->
-                    <release>21</release>
+                    <release>25</release>
                     <encoding>UTF-8</encoding>
                     <parameters>true</parameters>
                     <!-- 添加参数 -->


### PR DESCRIPTION
## Sourcery 总结

通过更新 GitHub Actions 工作流和 Maven 编译器插件设置，将项目的 Java 版本从 21 升级到 25

改进：
- 将 Maven 编译器插件的发布目标提升至 Java 25

CI：
- 更新 GitHub Actions 的 setup-java 步骤以使用 JDK 25

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade project's Java version from 21 to 25 by updating GitHub Actions workflow and Maven compiler plugin settings

Enhancements:
- Bump Maven compiler plugin release target to Java 25

CI:
- Update GitHub Actions setup-java step to use JDK 25

</details>